### PR TITLE
Add support for extra invitation languages

### DIFF
--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -32,7 +32,7 @@ class InvitationController extends Controller
             'ensemble'    => 'required|string|max:255',
             'director'    => 'nullable|string|max:255',
             'leader'      => 'nullable|string|max:255',
-            'language'    => 'required|in:mk,en,sr',
+            'language'    => 'required|in:mk,en,sr,bg,hr,pl,ro,tr,uk',
             'custom_date' => 'nullable|string|max:255',
         ]);
 
@@ -65,8 +65,8 @@ class InvitationController extends Controller
             // Име според јазик
             $data['festival_name'] = match ($request->language) {
                 'mk' => $festival->name_mk,
-                'en' => $festival->name_en,
                 'sr' => $festival->name_sr,
+                default => $festival->name_en,
             };
 
             // Датуми
@@ -86,6 +86,12 @@ class InvitationController extends Controller
             'mk' => 'invitation.pdf-mk',
             'en' => 'invitation.pdf-en',
             'sr' => 'invitation.pdf-sr',
+            'bg' => 'invitation.pdf-bg',
+            'hr' => 'invitation.pdf-hr',
+            'pl' => 'invitation.pdf-pl',
+            'ro' => 'invitation.pdf-ro',
+            'tr' => 'invitation.pdf-tr',
+            'uk' => 'invitation.pdf-uk',
         };
 
         // 6. Генерирање PDF

--- a/resources/views/invitation/form.blade.php
+++ b/resources/views/invitation/form.blade.php
@@ -21,7 +21,13 @@
                     <option value="">-- Choose Language --</option>
                     <option value="en">English</option>
                     <option value="mk">Macedonian</option>
-                    <option value="sr">Serbian/Croatian</option>
+                    <option value="sr">Serbian</option>
+                    <option value="bg">Bulgarian</option>
+                    <option value="hr">Croatian</option>
+                    <option value="pl">Polish</option>
+                    <option value="ro">Romanian</option>
+                    <option value="tr">Turkish</option>
+                    <option value="uk">Ukrainian</option>
                 </select>
             </div>
 
@@ -80,7 +86,7 @@
         const uniqueNames = {};
 
         festivals.forEach(f => {
-            const label = f[`name_${lang}`];
+            const label = f[`name_${lang}`] || f.name_en;
             if (!uniqueNames[label]) uniqueNames[label] = [];
             uniqueNames[label].push(f);
         });
@@ -96,7 +102,7 @@
 
     festivalNameSelect.addEventListener('change', function () {
         const lang = languageSelect.value;
-        const selected = festivals.filter(f => f[`name_${lang}`] === this.value);
+        const selected = festivals.filter(f => (f[`name_${lang}`] || f.name_en) === this.value);
 
         festivalIdSelect.innerHTML = '<option value="">-- Select Date --</option>';
         selected.forEach(f => {


### PR DESCRIPTION
## Summary
- update language dropdown in form
- support new languages in InvitationController
- gracefully handle missing translations in JS

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684af9b1e8fc8328a98edbd81a0ae473